### PR TITLE
Move push logic from docker_publish to external script in .github

### DIFF
--- a/.github/push.sh
+++ b/.github/push.sh
@@ -1,0 +1,21 @@
+# Pushes image to logged in docker registry (tagged with github ref)
+
+IMAGE_ID=$1
+
+# Change all uppercase to lowercase
+IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+# Strip git ref prefix from version
+VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+# Strip "v" prefix from tag name
+[[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+# Use docker `latest` tag convention
+[ "$VERSION" == "master" ] && VERSION=latest
+
+echo IMAGE_ID=$IMAGE_ID
+echo VERSION=$VERSION
+
+docker tag $IMAGE_ID $IMAGE_ID:$VERSION
+docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -9,7 +9,6 @@ on:
 jobs:
 
   openssl-cve-2014-0160:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -21,30 +20,11 @@ jobs:
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
     - name: Push the docker image
-      run: |
-        IMAGE_ID=forallsecure/openssl-cve-2014-0160
-
-        # Change all uppercase to lowercase
-        IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-        # Strip git ref prefix from version
-        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-        # Strip "v" prefix from tag name
-        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-        # Use docker `latest` tag convention
-        [ "$VERSION" == "master" ] && VERSION=latest
-
-        echo IMAGE_ID=$IMAGE_ID
-        echo VERSION=$VERSION
-
-        docker tag $IMAGE_ID $IMAGE_ID:$VERSION
-        docker push $IMAGE_ID:$VERSION
+      run: ./.github/push.sh forallsecure/openssl-cve-2014-0160
 
   cereal-cve-2020-11104-11105:
-
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
@@ -54,23 +34,4 @@ jobs:
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
     - name: Push the docker image
-      run: |
-        IMAGE_ID=forallsecure/cereal-cve-2020-11104-11105
-
-        # Change all uppercase to lowercase
-        IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-        # Strip git ref prefix from version
-        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-        # Strip "v" prefix from tag name
-        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-        # Use docker `latest` tag convention
-        [ "$VERSION" == "master" ] && VERSION=latest
-
-        echo IMAGE_ID=$IMAGE_ID
-        echo VERSION=$VERSION
-
-        docker tag $IMAGE_ID $IMAGE_ID:$VERSION
-        docker push $IMAGE_ID:$VERSION
+      run: ./.github/push.sh forallsecure/cereal-cve-2020-11104-11105


### PR DESCRIPTION
This MR moves the docker push logic from individual CI phases (duplicated) to a single push.sh script. This lowers chance for error (due to copy/paste) and makes correcting existing errors easier. Additionally, this cleans up and makes the publish_docker.yml more readable and declarative.