### PR TITLE
CI improvements -- don't fail builds on PR's

### DIFF
--- a/.github/login.sh
+++ b/.github/login.sh
@@ -1,0 +1,16 @@
+# Logs into docker if credentials are provided
+
+USER=$1
+PASSWD=$2
+
+if [[ -z "$USER" ]]; then
+    echo "no username provided -- not logging in"
+    exit 0
+fi
+
+if [[ -z "$PASSWD" ]]; then
+    echo "no password provided -- not logging in"
+    exit 0
+fi
+
+echo "$PASSWD" | docker login -u "$USER" --password-stdin

--- a/.github/push.sh
+++ b/.github/push.sh
@@ -3,6 +3,7 @@
 IMAGE_ID=$1
 REF=$2
 
+mkdir -p ~/.docker/
 touch ~/.docker/config.json
 (grep -q "index.docker.io" ~/.docker/config.json)
 LOGGED_OUT=$?

--- a/.github/push.sh
+++ b/.github/push.sh
@@ -1,7 +1,15 @@
-# Pushes image to logged in docker registry (tagged with github ref)
+# Pushes image to logged in docker registry (tagged with github ref) if logged in
 
 IMAGE_ID=$1
 REF=$2
+
+(grep -q "index.docker.io" ~/.docker/config.json)
+LOGGED_OUT=$?
+
+if [[ $LOGGED_OUT = 1 ]]; then
+    echo "Not logged into docker -- not pushing"
+    exit 0
+fi
 
 # Change all uppercase to lowercase
 IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')

--- a/.github/push.sh
+++ b/.github/push.sh
@@ -3,6 +3,7 @@
 IMAGE_ID=$1
 REF=$2
 
+touch ~/.docker/config.json
 (grep -q "index.docker.io" ~/.docker/config.json)
 LOGGED_OUT=$?
 

--- a/.github/push.sh
+++ b/.github/push.sh
@@ -19,7 +19,7 @@ IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
 VERSION=$(echo "$REF" | sed -e 's,.*/\(.*\),\1,')
 
 # Strip "v" prefix from tag name
-[[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+[[ "$REF" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
 # Use docker `latest` tag convention
 [ "$VERSION" == "master" ] && VERSION=latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -17,7 +17,7 @@ jobs:
       run: ./mayhemit.sh --build openssl-cve-2014-0160
 
     - name: Log into the registry
-      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      run: ./.github/login.sh "${{ secrets.DOCKER_USERNAME }}" "${{ secrets.DOCKER_PASSWORD }}"
 
     - name: Push the docker image
       run: ./.github/push.sh forallsecure/openssl-cve-2014-0160 "${{ github.ref }}"
@@ -31,7 +31,7 @@ jobs:
       run: ./mayhemit.sh --build cereal-cve-2020-11104-11105
 
     - name: Log into the registry
-      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      run: ./.github/login.sh "${{ secrets.DOCKER_USERNAME }}" "${{ secrets.DOCKER_PASSWORD }}"
 
     - name: Push the docker image
       run: ./.github/push.sh forallsecure/cereal-cve-2020-11104-11105 "${{ github.ref }}"


### PR DESCRIPTION
This build allows the docker login and docker push steps in the jobs to pass even if the information is not present.

This is necessary b/c the workflow runs on PR's don't have access to the secrets and autofail these parts. This effectively skips them when run on PR's.