### PR TITLE
Update Mayhemfiles to work on current version

### DIFF
--- a/cereal-cve-2020-11104-11105/mayhem/cereal-32bit/Mayhemfile
+++ b/cereal-cve-2020-11104-11105/mayhem/cereal-32bit/Mayhemfile
@@ -1,9 +1,8 @@
-version: '1.3'
 project: cereal-cve-2020-11104-11105
 target: cereal-32bit
-baseimage: forallsecure/cereal-cve-2020-11104-11105
+image: forallsecure/cereal-cve-2020-11104-11105
 duration: 30
 cmds:
 -   cmd: /src/cereal/fuzzer/fuzzer32
     libfuzzer: true
-    asan: true
+    sanitizer: true

--- a/cereal-cve-2020-11104-11105/mayhem/cereal-standalone/Mayhemfile
+++ b/cereal-cve-2020-11104-11105/mayhem/cereal-standalone/Mayhemfile
@@ -1,7 +1,6 @@
-version: '1.3'
 project: cereal-cve-2020-11104-11105
 target: cereal-standalone
-baseimage: forallsecure/cereal-cve-2020-11104-11105
+image: forallsecure/cereal-cve-2020-11104-11105
 duration: 30
 advanced_triage: true
 cmds:

--- a/cereal-cve-2020-11104-11105/mayhem/cereal/Mayhemfile
+++ b/cereal-cve-2020-11104-11105/mayhem/cereal/Mayhemfile
@@ -1,9 +1,8 @@
-version: '1.3'
 project: cereal-cve-2020-11104-11105
 target: cereal
-baseimage: forallsecure/cereal-cve-2020-11104-11105
+image: forallsecure/cereal-cve-2020-11104-11105
 duration: 30
 cmds:
 -   cmd: /src/cereal/fuzzer/fuzzer
     libfuzzer: true
-    asan: true
+    sanitizer: true

--- a/jq-defect-2020/mayhem/jq_parse_fuzzer/Mayhemfile
+++ b/jq-defect-2020/mayhem/jq_parse_fuzzer/Mayhemfile
@@ -1,7 +1,6 @@
-version: '1.5'
 project: jq-defect-2020
 target: jq_parse_fuzzer
-baseimage: forallsecure/jq-defect-2020
+image: forallsecure/jq-defect-2020
 duration: 1200
 
 cmds:

--- a/libm-cve-2020-10029/mayhem/libm-tester/Mayhemfile
+++ b/libm-cve-2020-10029/mayhem/libm-tester/Mayhemfile
@@ -1,7 +1,6 @@
-version: '1.4'
 project: libm-cve-2020-10029
 target: libm-tester
-baseimage: forallsecure/libm-cve-2020-10029
+image: forallsecure/libm-cve-2020-10029
 duration: 600
 advanced_triage: true
 

--- a/matio-cve-2019-13107/mayhem/matio/Mayhemfile
+++ b/matio-cve-2019-13107/mayhem/matio/Mayhemfile
@@ -1,7 +1,6 @@
-version: '1.3'
 project: matio-cve-2019-13107
 target: matio
-baseimage: forallsecure/matio-cve-2019-13107
+image: forallsecure/matio-cve-2019-13107
 cmds:
   - cmd: /mayhem/matio-libfuzzer
   - cmd: /mayhem/matio-standalone @@

--- a/ncsahttpd-cve-1999-0067/mayhem/phf/Mayhemfile
+++ b/ncsahttpd-cve-1999-0067/mayhem/phf/Mayhemfile
@@ -1,7 +1,6 @@
-version: '1.9'
 project: ncsa-httpd
 target: phf
-baseimage: $MAYHEM_DOCKER_REGISTRY/phf
+image: forallsecure/ncsahttpd-cve-1999-0067
 
 duration: 300 # normally takes ~30s but let's be safe
 advanced_triage: true

--- a/netflix-cve-2019-10028/mayhem/dial/Mayhemfile
+++ b/netflix-cve-2019-10028/mayhem/dial/Mayhemfile
@@ -1,7 +1,6 @@
-version: '1.8'
 project: netflix-cve-2019-10028
 target: dial
-baseimage: forallsecure/netflix-cve-2019-10028
+image: forallsecure/netflix-cve-2019-10028
 duration: 120
 advanced_triage: true
 
@@ -10,5 +9,5 @@ cmds:
     dictionary: /fuzz/server/http.dict
     network:
       url: tcp://localhost:56790
-      is_client: false
+      client: false
       timeout: 2.0

--- a/objdump-cve-2017-124xx/mayhem/objdump/Mayhemfile
+++ b/objdump-cve-2017-124xx/mayhem/objdump/Mayhemfile
@@ -1,7 +1,6 @@
-version: '1.4'
 project: objdump-cve-2017-124xx
 target: objdump
-baseimage: forallsecure/objdump-cve-2017-124xx
+image: forallsecure/objdump-cve-2017-124xx
 advanced_triage: true
 duration: 3600
 cmds:

--- a/oniguruma-cve-2019-13224-13225/mayhem/oniguruma/Mayhemfile
+++ b/oniguruma-cve-2019-13224-13225/mayhem/oniguruma/Mayhemfile
@@ -1,7 +1,6 @@
-version: '1.0'
 project: oniguruma
 target: deluxe
-baseimage: forallsecure/oniguruma-cve-2019-13224-13225
+image: forallsecure/oniguruma-cve-2019-13224-13225
 duration: 600
 
 cmds:

--- a/openssl-cve-2014-0160/mayhem/heartbleed/Mayhemfile
+++ b/openssl-cve-2014-0160/mayhem/heartbleed/Mayhemfile
@@ -1,10 +1,9 @@
-version: '1.3'
 project: openssl-cve-2014-0160
 target: heartbleed
-baseimage: forallsecure/openssl-cve-2014-0160
+image: forallsecure/openssl-cve-2014-0160
 duration: 30
 
 cmds:
   - cmd: /build/handshake-fuzzer
     libfuzzer: true
-    asan: true
+    sanitizer: true

--- a/sixlibrary-defect-2020/mayhem/test-extract-xml/Mayhemfile
+++ b/sixlibrary-defect-2020/mayhem/test-extract-xml/Mayhemfile
@@ -1,7 +1,6 @@
-version: "1.7"
 project: six
 target: test-extract-xml
-baseimage: $MAYHEM_DOCKER_REGISTRY/six
+image: forallsecure/sixlibrary-defect-2020
 duration: 86400
 advanced_triage: true
 

--- a/stb-cve-2019-132xx/mayhem/stb-vorbis/Mayhemfile
+++ b/stb-cve-2019-132xx/mayhem/stb-vorbis/Mayhemfile
@@ -1,7 +1,6 @@
-version: '1.3'
 project: stb-cve-2019-132xx
 target: stb-vorbis
-baseimage: forallsecure/stb-cve-2019-132xx
+image: forallsecure/stb-cve-2019-132xx
 duration: 900
 cmds:
   - cmd: /mayhem/stb-vorbis-libfuzzer

--- a/sthttpd-cve-2017-10671/mayhem/sthttpd/Mayhemfile
+++ b/sthttpd-cve-2017-10671/mayhem/sthttpd/Mayhemfile
@@ -1,12 +1,11 @@
-version: '1.4'
 project: sthttpd-cve-2017-10671
 target: sthttpd
-baseimage: forallsecure/sthttpd-cve-2017-10671
+image: forallsecure/sthttpd-cve-2017-10671
 advanced_triage: true
 duration: 3600
 cmds:
 - cmd: /fuzz/thttpd -D -p 12200
   network:
-    is_client: false
+    client: false
     timeout: 2.0
     url: tcp://127.0.0.1:12200

--- a/uboot-cve-2019-13103-13106/mayhem/uboot/Mayhemfile
+++ b/uboot-cve-2019-13103-13106/mayhem/uboot/Mayhemfile
@@ -1,9 +1,8 @@
-version: '1.4'
 project: uboot-cve-2019-13103-13106
 target: uboot
-baseimage: forallsecure/uboot-cve-2019-13103-13106
+image: forallsecure/uboot-cve-2019-13103-13106
 duration: 86400 # takes about 9 hrs to find first bug
 cmds:
   - cmd: /mayhem/u-boot-2019.07-rc4/u-boot -c "host bind 0 /fs.ext4 ; ls host 0"
-    target_input: /fs.ext4
+    filepath: /fs.ext4
     timeout: 10


### PR DESCRIPTION
Update mayhemfile syntax to comply with latest Mayhemfile syntax, uniformly refer to docker images on dockerhub by default.